### PR TITLE
Complete Rewrite of the Tuners

### DIFF
--- a/TeamCode/src/main/java/core/ApexConfig.java
+++ b/TeamCode/src/main/java/core/ApexConfig.java
@@ -5,7 +5,7 @@ import localizers.BaseLocalizerConfig;
 
 /**
  * Abstract base class for your constants
- * Method implemented by {@link org.firstinspires.ftc.teamcode.Constants}
+ * Methods implemented by your Constants file
  * @author Dylan B. 18597 RoboClovers - Delta
  * @author Sohum Arora 22985 Paraducks
  */

--- a/TeamCode/src/main/java/core/ApexConfig.java
+++ b/TeamCode/src/main/java/core/ApexConfig.java
@@ -13,5 +13,5 @@ public abstract class ApexConfig {
 
     public abstract BaseLocalizerConfig<?> localizerConfig();
 
-    public abstract FollowerContants followerConfig();
+    public abstract FollowerConstants followerConfig();
 }

--- a/TeamCode/src/main/java/core/ApexConfig.java
+++ b/TeamCode/src/main/java/core/ApexConfig.java
@@ -7,6 +7,7 @@ import localizers.BaseLocalizerConfig;
  * Abstract base class for your constants
  * Method implemented by {@link org.firstinspires.ftc.teamcode.Constants}
  * @author Dylan B. 18597 RoboClovers - Delta
+ * @author Sohum Arora 22985 Paraducks
  */
 public abstract class ApexConfig {
     public abstract BaseDrivetrainConfig<?> drivetrainConfig();

--- a/TeamCode/src/main/java/core/ApexConfig.java
+++ b/TeamCode/src/main/java/core/ApexConfig.java
@@ -12,6 +12,6 @@ public abstract class ApexConfig {
     public abstract BaseDrivetrainConfig<?> drivetrainConfig();
 
     public abstract BaseLocalizerConfig<?> localizerConfig();
-
     public abstract FollowerConstants followerConfig();
+
 }

--- a/TeamCode/src/main/java/core/ApexConfig.java
+++ b/TeamCode/src/main/java/core/ApexConfig.java
@@ -3,8 +3,9 @@ package core;
 import drivetrains.BaseDrivetrainConfig;
 import localizers.BaseLocalizerConfig;
 
-// TODO: Rewrite JavaDocs
 /**
+ * Abstract base class for your constants
+ * Method implemented by {@link org.firstinspires.ftc.teamcode.Constants}
  * @author Dylan B. 18597 RoboClovers - Delta
  */
 public abstract class ApexConfig {
@@ -12,5 +13,5 @@ public abstract class ApexConfig {
 
     public abstract BaseLocalizerConfig<?> localizerConfig();
 
-    public abstract FollowerConfig followerConfig();
+    public abstract FollowerContants followerConfig();
 }

--- a/TeamCode/src/main/java/core/Follower.java
+++ b/TeamCode/src/main/java/core/Follower.java
@@ -23,7 +23,7 @@ import paths.movements.Turn;
  * @author Xander Haemel 31616 404 Not Found
  */
 public class Follower {
-    private final FollowerContants config;
+    private final FollowerConstants config;
     private final BaseDrivetrain<?> drivetrain;
     private final BaseLocalizer<?> localizer;
 

--- a/TeamCode/src/main/java/core/Follower.java
+++ b/TeamCode/src/main/java/core/Follower.java
@@ -23,7 +23,7 @@ import paths.movements.Turn;
  * @author Xander Haemel 31616 404 Not Found
  */
 public class Follower {
-    private final FollowerConfig config;
+    private final FollowerContants config;
     private final BaseDrivetrain<?> drivetrain;
     private final BaseLocalizer<?> localizer;
 
@@ -148,7 +148,7 @@ public class Follower {
             double feedforward = 0.0;
             double tangentFeedbackMag;
             if (t < 1.0) {
-                feedforward = (config.kV * desiredVelocity) + (config.kA * requiredAccel) + velocityS;
+                feedforward = (config.lateralKV * desiredVelocity) + (config.lateralKA * requiredAccel) + velocityS;
 
                 double alongTrackError = fieldError.dot(unitTangent).getIn();
                 tangentFeedbackMag = driveController.calculateFromError(alongTrackError);

--- a/TeamCode/src/main/java/core/FollowerConstants.java
+++ b/TeamCode/src/main/java/core/FollowerConstants.java
@@ -9,7 +9,7 @@ import geometry.Dist;
  *
  * @author Dylan B. - 18597 RoboClovers - Delta
  */
-public class FollowerContants {
+public class FollowerConstants {
     public PDSCoefficients headingCoeffs = new PDSCoefficients();
     public PDSCoefficients lateralCoeffs = new PDSCoefficients();
     public PDSCoefficients driveCoeffs = new PDSCoefficients();
@@ -25,57 +25,57 @@ public class FollowerContants {
     public double maxLateralAccel = 0;
 
     /** Set the heading controller PDS coefficients. By default, all values are zero. */
-    public FollowerContants setHeadingCoeffs(PDSCoefficients headingCoeffs) {
+    public FollowerConstants setHeadingCoeffs(PDSCoefficients headingCoeffs) {
         this.headingCoeffs = headingCoeffs; return this;
     }
 
     /** Set the lateral controller PDS coefficients. By default, all values are zero. */
-    public FollowerContants setLateralCoeffs(PDSCoefficients lateralCoeffs) {
+    public FollowerConstants setLateralCoeffs(PDSCoefficients lateralCoeffs) {
         this.lateralCoeffs = lateralCoeffs; return this;
     }
 
     /** Set the drive controller PDS coefficients. By default, all values are zero. */
-    public FollowerContants setDriveCoeffs(PDSCoefficients driveCoeffs) {
+    public FollowerConstants setDriveCoeffs(PDSCoefficients driveCoeffs) {
         this.driveCoeffs = driveCoeffs; return this;
     }
 
     /** Set the velocity controller PDS coefficients. By default, all values are zero. */
-    public FollowerContants setVelocityCoeffs(PDSCoefficients velocityCoeffs) {
+    public FollowerConstants setVelocityCoeffs(PDSCoefficients velocityCoeffs) {
         this.velocityCoeffs = velocityCoeffs; return this;
     }
 
     /** Set the heading feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerContants setFeedforwardCoeffs(double headingKV, double headingKA) {
+    public FollowerConstants setFeedforwardCoeffs(double headingKV, double headingKA) {
         this.headingKV = headingKV; this.headingKA = headingKA; return this;
     }
 
     /** Set the lateral feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerContants setLateralFeedforwardCoeffs(double kV, double kA) {
+    public FollowerConstants setLateralFeedforwardCoeffs(double kV, double kA) {
         this.lateralKV = kV; this.lateralKA = kA; return this;
     }
 
     /** Set the velocity limit for the follower. By default, there is no limit. */
-    public FollowerContants setVelocityLimit(Dist velocityLimit) {
+    public FollowerConstants setVelocityLimit(Dist velocityLimit) {
         this.velocityLimit = velocityLimit; return this;
     }
 
     /** Set the heading tolerance for the follower. By default, it is 1 degree. */
-    public FollowerContants setHeadingTolerance(Angle headingTolerance) {
+    public FollowerConstants setHeadingTolerance(Angle headingTolerance) {
         this.headingTolerance = headingTolerance; return this;
     }
 
     /** Set the distance tolerance for the follower. By default, it is 0.5 inches. */
-    public FollowerContants setDistanceTolerance(Dist distanceTolerance) {
+    public FollowerConstants setDistanceTolerance(Dist distanceTolerance) {
         this.distanceTolerance = distanceTolerance; return this;
     }
 
     /** Set the t tolerance for the follower. By default, it is 0.95. */
-    public FollowerContants setTTolerance(double tTolerance) {
+    public FollowerConstants setTTolerance(double tTolerance) {
         this.tTolerance = tTolerance; return this;
     }
 
     /** Set the maximum lateral acceleration for the follower. By default, there is no limit. */
-    public FollowerContants setMaxLateralAccel(double maxLateralAccel) {
+    public FollowerConstants setMaxLateralAccel(double maxLateralAccel) {
         this.maxLateralAccel = maxLateralAccel; return this;
     }
 }

--- a/TeamCode/src/main/java/core/FollowerConstants.java
+++ b/TeamCode/src/main/java/core/FollowerConstants.java
@@ -15,29 +15,18 @@ import java.io.FileReader;
  * @author Sohum Arora 22985 Paraducks
  */
 public class FollowerConstants {
-    public PDSCoefficients headingCoeffs;
-    public PDSCoefficients lateralCoeffs;
-    public PDSCoefficients driveCoeffs;
-    public PDSCoefficients velocityCoeffs;
-
-    public double headingKV = 0.0, headingKA = 0.0;
+    public PDSCoefficients headingCoeffs = new PDSCoefficients();
+    public PDSCoefficients lateralCoeffs = new PDSCoefficients();
+    public PDSCoefficients driveCoeffs = new PDSCoefficients();
+    public PDSCoefficients velocityCoeffs = new PDSCoefficients();
     public double lateralKV = 0.0, lateralKA = 0.0;
     public Dist velocityLimit = null;
+    public Angle headingTolerance = Angle.fromDeg(1.0);
+    public Dist distanceTolerance = Dist.fromIn(0.5);
+    public double tTolerance = 0.95;
+    public double maxLateralAccel = 40.0;
 
-    public Angle headingTolerance;
-    public Dist distanceTolerance;
-    public double tTolerance;
-    public double maxLateralAccel;
-
-    public FollowerConstants() { //Values 0 to begin with
-        this.headingCoeffs = new PDSCoefficients();
-        this.driveCoeffs = new PDSCoefficients();
-        this.lateralCoeffs = new PDSCoefficients();
-        this.velocityCoeffs = new PDSCoefficients();
-        this.headingTolerance = Angle.fromDeg(1.0);
-        this.distanceTolerance = Dist.fromIn(0.5);
-        this.tTolerance = 0.95;
-        this.maxLateralAccel = 40.0;
+    public FollowerConstants() {
         loadValues();
     }
 
@@ -75,7 +64,7 @@ public class FollowerConstants {
             }
         }
     }
-    public FollowerConstants loadFromJson() {
+    public FollowerConstants getConstants() {
         return this;
     }
 }

--- a/TeamCode/src/main/java/core/FollowerConstants.java
+++ b/TeamCode/src/main/java/core/FollowerConstants.java
@@ -3,79 +3,86 @@ package core;
 import controllers.PDSController.PDSCoefficients;
 import geometry.Angle;
 import geometry.Dist;
+import org.json.JSONObject;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.FileReader;
 
 /**
- * Apex Pathing Follower configuration class.
- *
- * @author Dylan B. - 18597 RoboClovers - Delta
+ * Apex Pathing FollowerConstants class
+ * Internally assigns the coefficient values determined through tuning directly.
+ * @author Sohum Arora 22985 Paraducks
  */
 public class FollowerConstants {
-    public PDSCoefficients headingCoeffs = new PDSCoefficients();
-    public PDSCoefficients lateralCoeffs = new PDSCoefficients();
-    public PDSCoefficients driveCoeffs = new PDSCoefficients();
-    public PDSCoefficients velocityCoeffs = new PDSCoefficients();
+    public PDSCoefficients headingCoeffs;
+    public PDSCoefficients lateralCoeffs;
+    public PDSCoefficients driveCoeffs;
+    public PDSCoefficients velocityCoeffs;
 
-    public double headingKV, headingKA = 0.0;
-    public double lateralKV, lateralKA = 0.0;
+    public double headingKV = 0.0, headingKA = 0.0;
+    public double lateralKV = 0.0, lateralKA = 0.0;
     public Dist velocityLimit = null;
 
-    public Angle headingTolerance = Angle.fromDeg(1.0);
-    public Dist distanceTolerance = Dist.fromIn(0.5);
-    public double tTolerance = 0.95;
-    public double maxLateralAccel = 0;
+    public Angle headingTolerance;
+    public Dist distanceTolerance;
+    public double tTolerance;
+    public double maxLateralAccel;
 
-    /** Set the heading controller PDS coefficients. By default, all values are zero. */
-    public FollowerConstants setHeadingCoeffs(PDSCoefficients headingCoeffs) {
-        this.headingCoeffs = headingCoeffs; return this;
+    public FollowerConstants() {
+        // Set Defaults
+        this.headingCoeffs = new PDSCoefficients();
+        this.driveCoeffs = new PDSCoefficients();
+        this.lateralCoeffs = new PDSCoefficients();
+        this.velocityCoeffs = new PDSCoefficients();
+        this.headingTolerance = Angle.fromDeg(1.0);
+        this.distanceTolerance = Dist.fromIn(0.5);
+        this.tTolerance = 0.95;
+        this.maxLateralAccel = 40.0;
+
+        // Perform actual loading
+        loadValues();
     }
 
-    /** Set the lateral controller PDS coefficients. By default, all values are zero. */
-    public FollowerConstants setLateralCoeffs(PDSCoefficients lateralCoeffs) {
-        this.lateralCoeffs = lateralCoeffs; return this;
+    private void loadValues() {
+        File file = new File("/sdcard/FIRST/FollowerConstants.json");
+        if (file.exists()) {
+            try {
+                BufferedReader reader = new BufferedReader(new FileReader(file));
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) sb.append(line);
+                reader.close();
+
+                JSONObject json = new JSONObject(sb.toString());
+
+                // Coefficients
+                this.headingCoeffs = new PDSCoefficients(
+                        json.optDouble("headingP", 0),
+                        json.optDouble("headingD", 0),
+                        json.optDouble("headingS", 0), 0);
+
+                double tP = json.optDouble("translationP", 0);
+                double tD = json.optDouble("translationD", 0);
+                double tS = json.optDouble("translationS", 0);
+                this.driveCoeffs = new PDSCoefficients(tP, tD, tS, 0);
+                this.lateralCoeffs = new PDSCoefficients(tP, tD, tS, 0);
+
+                // Settings
+                this.lateralKV = json.optDouble("velocityFF", this.lateralKV);
+                this.maxLateralAccel = json.optDouble("maxLateralAccel", this.maxLateralAccel);
+                this.headingTolerance = Angle.fromDeg(json.optDouble("headingToleranceDeg", 1.0));
+                this.distanceTolerance = Dist.fromIn(json.optDouble("distanceToleranceIn", 0.5));
+                this.tTolerance = json.optDouble("tTolerance", 0.95);
+
+            } catch (Exception ignored) { }
+        }
     }
 
-    /** Set the drive controller PDS coefficients. By default, all values are zero. */
-    public FollowerConstants setDriveCoeffs(PDSCoefficients driveCoeffs) {
-        this.driveCoeffs = driveCoeffs; return this;
-    }
-
-    /** Set the velocity controller PDS coefficients. By default, all values are zero. */
-    public FollowerConstants setVelocityCoeffs(PDSCoefficients velocityCoeffs) {
-        this.velocityCoeffs = velocityCoeffs; return this;
-    }
-
-    /** Set the heading feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerConstants setFeedforwardCoeffs(double headingKV, double headingKA) {
-        this.headingKV = headingKV; this.headingKA = headingKA; return this;
-    }
-
-    /** Set the lateral feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerConstants setLateralFeedforwardCoeffs(double kV, double kA) {
-        this.lateralKV = kV; this.lateralKA = kA; return this;
-    }
-
-    /** Set the velocity limit for the follower. By default, there is no limit. */
-    public FollowerConstants setVelocityLimit(Dist velocityLimit) {
-        this.velocityLimit = velocityLimit; return this;
-    }
-
-    /** Set the heading tolerance for the follower. By default, it is 1 degree. */
-    public FollowerConstants setHeadingTolerance(Angle headingTolerance) {
-        this.headingTolerance = headingTolerance; return this;
-    }
-
-    /** Set the distance tolerance for the follower. By default, it is 0.5 inches. */
-    public FollowerConstants setDistanceTolerance(Dist distanceTolerance) {
-        this.distanceTolerance = distanceTolerance; return this;
-    }
-
-    /** Set the t tolerance for the follower. By default, it is 0.95. */
-    public FollowerConstants setTTolerance(double tTolerance) {
-        this.tTolerance = tTolerance; return this;
-    }
-
-    /** Set the maximum lateral acceleration for the follower. By default, there is no limit. */
-    public FollowerConstants setMaxLateralAccel(double maxLateralAccel) {
-        this.maxLateralAccel = maxLateralAccel; return this;
+    /**
+     * Kept for compatibility with FollowerTuner.java.
+     * Constructor already handles the logic; this simply returns the object.
+     */
+    public FollowerConstants loadFromJson() {
+        return this;
     }
 }

--- a/TeamCode/src/main/java/core/FollowerConstants.java
+++ b/TeamCode/src/main/java/core/FollowerConstants.java
@@ -10,7 +10,8 @@ import java.io.FileReader;
 
 /**
  * Apex Pathing FollowerConstants class
- * Internally assigns the coefficient values determined through tuning directly.
+ * Internally assigns the coefficient values determined through tuning directly,
+ * thereby eliminating the need to manually tune and set the values in the Constants file!
  * @author Sohum Arora 22985 Paraducks
  */
 public class FollowerConstants {
@@ -28,8 +29,7 @@ public class FollowerConstants {
     public double tTolerance;
     public double maxLateralAccel;
 
-    public FollowerConstants() {
-        // Set Defaults
+    public FollowerConstants() { //Values 0 to begin with
         this.headingCoeffs = new PDSCoefficients();
         this.driveCoeffs = new PDSCoefficients();
         this.lateralCoeffs = new PDSCoefficients();
@@ -38,8 +38,6 @@ public class FollowerConstants {
         this.distanceTolerance = Dist.fromIn(0.5);
         this.tTolerance = 0.95;
         this.maxLateralAccel = 40.0;
-
-        // Perform actual loading
         loadValues();
     }
 
@@ -55,7 +53,6 @@ public class FollowerConstants {
 
                 JSONObject json = new JSONObject(sb.toString());
 
-                // Coefficients
                 this.headingCoeffs = new PDSCoefficients(
                         json.optDouble("headingP", 0),
                         json.optDouble("headingD", 0),
@@ -67,21 +64,17 @@ public class FollowerConstants {
                 this.driveCoeffs = new PDSCoefficients(tP, tD, tS, 0);
                 this.lateralCoeffs = new PDSCoefficients(tP, tD, tS, 0);
 
-                // Settings
                 this.lateralKV = json.optDouble("velocityFF", this.lateralKV);
                 this.maxLateralAccel = json.optDouble("maxLateralAccel", this.maxLateralAccel);
                 this.headingTolerance = Angle.fromDeg(json.optDouble("headingToleranceDeg", 1.0));
                 this.distanceTolerance = Dist.fromIn(json.optDouble("distanceToleranceIn", 0.5));
                 this.tTolerance = json.optDouble("tTolerance", 0.95);
 
-            } catch (Exception ignored) { }
+            } catch (Exception ignored) {
+                //defaults to 0 values everywhere
+            }
         }
     }
-
-    /**
-     * Kept for compatibility with FollowerTuner.java.
-     * Constructor already handles the logic; this simply returns the object.
-     */
     public FollowerConstants loadFromJson() {
         return this;
     }

--- a/TeamCode/src/main/java/core/FollowerContants.java
+++ b/TeamCode/src/main/java/core/FollowerContants.java
@@ -9,7 +9,7 @@ import geometry.Dist;
  *
  * @author Dylan B. - 18597 RoboClovers - Delta
  */
-public class FollowerConfig {
+public class FollowerContants {
     public PDSCoefficients headingCoeffs = new PDSCoefficients();
     public PDSCoefficients lateralCoeffs = new PDSCoefficients();
     public PDSCoefficients driveCoeffs = new PDSCoefficients();
@@ -25,57 +25,57 @@ public class FollowerConfig {
     public double maxLateralAccel = 0;
 
     /** Set the heading controller PDS coefficients. By default, all values are zero. */
-    public FollowerConfig setHeadingCoeffs(PDSCoefficients headingCoeffs) {
+    public FollowerContants setHeadingCoeffs(PDSCoefficients headingCoeffs) {
         this.headingCoeffs = headingCoeffs; return this;
     }
 
     /** Set the lateral controller PDS coefficients. By default, all values are zero. */
-    public FollowerConfig setLateralCoeffs(PDSCoefficients lateralCoeffs) {
+    public FollowerContants setLateralCoeffs(PDSCoefficients lateralCoeffs) {
         this.lateralCoeffs = lateralCoeffs; return this;
     }
 
     /** Set the drive controller PDS coefficients. By default, all values are zero. */
-    public FollowerConfig setDriveCoeffs(PDSCoefficients driveCoeffs) {
+    public FollowerContants setDriveCoeffs(PDSCoefficients driveCoeffs) {
         this.driveCoeffs = driveCoeffs; return this;
     }
 
     /** Set the velocity controller PDS coefficients. By default, all values are zero. */
-    public FollowerConfig setVelocityCoeffs(PDSCoefficients velocityCoeffs) {
+    public FollowerContants setVelocityCoeffs(PDSCoefficients velocityCoeffs) {
         this.velocityCoeffs = velocityCoeffs; return this;
     }
 
     /** Set the heading feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerConfig setFeedforwardCoeffs(double headingKV, double headingKA) {
+    public FollowerContants setFeedforwardCoeffs(double headingKV, double headingKA) {
         this.headingKV = headingKV; this.headingKA = headingKA; return this;
     }
 
     /** Set the lateral feedforward velocity and acceleration coefficients. By default, both values are zero. */
-    public FollowerConfig setLateralFeedforwardCoeffs(double kV, double kA) {
+    public FollowerContants setLateralFeedforwardCoeffs(double kV, double kA) {
         this.lateralKV = kV; this.lateralKA = kA; return this;
     }
 
     /** Set the velocity limit for the follower. By default, there is no limit. */
-    public FollowerConfig setVelocityLimit(Dist velocityLimit) {
+    public FollowerContants setVelocityLimit(Dist velocityLimit) {
         this.velocityLimit = velocityLimit; return this;
     }
 
     /** Set the heading tolerance for the follower. By default, it is 1 degree. */
-    public FollowerConfig setHeadingTolerance(Angle headingTolerance) {
+    public FollowerContants setHeadingTolerance(Angle headingTolerance) {
         this.headingTolerance = headingTolerance; return this;
     }
 
     /** Set the distance tolerance for the follower. By default, it is 0.5 inches. */
-    public FollowerConfig setDistanceTolerance(Dist distanceTolerance) {
+    public FollowerContants setDistanceTolerance(Dist distanceTolerance) {
         this.distanceTolerance = distanceTolerance; return this;
     }
 
     /** Set the t tolerance for the follower. By default, it is 0.95. */
-    public FollowerConfig setTTolerance(double tTolerance) {
+    public FollowerContants setTTolerance(double tTolerance) {
         this.tTolerance = tTolerance; return this;
     }
 
     /** Set the maximum lateral acceleration for the follower. By default, there is no limit. */
-    public FollowerConfig setMaxLateralAccel(double maxLateralAccel) {
+    public FollowerContants setMaxLateralAccel(double maxLateralAccel) {
         this.maxLateralAccel = maxLateralAccel; return this;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
@@ -2,7 +2,7 @@ package org.firstinspires.ftc.teamcode;
 
 import controllers.PDSController;
 import core.ApexConfig;
-import core.FollowerContants;
+import core.FollowerConstants;
 import drivetrains.BaseDrivetrainConfig;
 import drivetrains.Mecanum;
 import localizers.BaseLocalizerConfig;
@@ -43,8 +43,8 @@ public class Constants extends ApexConfig {
     }
 
     @Override
-    public FollowerContants followerConfig() {
-        return new FollowerContants()
+    public FollowerConstants followerConfig() {
+        return new FollowerConstants()
                 .setHeadingCoeffs(new PDSController.PDSCoefficients())
                 .setLateralCoeffs(new PDSController.PDSCoefficients())
                 .setDriveCoeffs(new PDSController.PDSCoefficients())

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
@@ -20,8 +20,13 @@ import util.MotorFactory;
  * your robot's hardware and tuning preferences.
  *
  * @author Dylan B. 18597 RoboClovers - Delta
+ * @author Sohum Arora 22985 Paraducks
  */
 public class Constants extends ApexConfig {
+    @Override
+    public FollowerConstants followerConfig() {
+        return new FollowerConstants();
+    }
     @Override
     public BaseDrivetrainConfig<?> drivetrainConfig() {
         return new Mecanum.Config()
@@ -40,21 +45,6 @@ public class Constants extends ApexConfig {
                 .setOffsets(0, 0, DistUnit.IN)
                 .setEncoderDirections(Pinpoint.EncoderDirection.FORWARD, Pinpoint.EncoderDirection.FORWARD)
                 .setEncoderResolution(Pinpoint.GoBildaPods.goBILDA_4_BAR_POD);
-    }
-
-    @Override
-    public FollowerConstants followerConfig() {
-        return new FollowerConstants()
-                .setHeadingCoeffs(new PDSController.PDSCoefficients())
-                .setLateralCoeffs(new PDSController.PDSCoefficients())
-                .setDriveCoeffs(new PDSController.PDSCoefficients())
-                .setVelocityCoeffs(new PDSController.PDSCoefficients())
-                .setFeedforwardCoeffs(0.0, 0.0)
-                .setVelocityLimit(Dist.fromIn(20))
-                .setHeadingTolerance(Angle.fromDeg(2.0))
-                .setDistanceTolerance(Dist.fromIn(1.0))
-                .setTTolerance(0.95)
-                .setMaxLateralAccel(10.0);
     }
 }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants.java
@@ -2,7 +2,7 @@ package org.firstinspires.ftc.teamcode;
 
 import controllers.PDSController;
 import core.ApexConfig;
-import core.FollowerConfig;
+import core.FollowerContants;
 import drivetrains.BaseDrivetrainConfig;
 import drivetrains.Mecanum;
 import localizers.BaseLocalizerConfig;
@@ -21,7 +21,7 @@ import util.MotorFactory;
  *
  * @author Dylan B. 18597 RoboClovers - Delta
  */
-public class Config extends ApexConfig {
+public class Constants extends ApexConfig {
     @Override
     public BaseDrivetrainConfig<?> drivetrainConfig() {
         return new Mecanum.Config()
@@ -43,8 +43,8 @@ public class Config extends ApexConfig {
     }
 
     @Override
-    public FollowerConfig followerConfig() {
-        return new FollowerConfig()
+    public FollowerContants followerConfig() {
+        return new FollowerContants()
                 .setHeadingCoeffs(new PDSController.PDSCoefficients())
                 .setLateralCoeffs(new PDSController.PDSCoefficients())
                 .setDriveCoeffs(new PDSController.PDSCoefficients())

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -172,6 +172,7 @@ public class FollowerTuner extends LinearOpMode {
                                 }
 
                                 updateFollowerConfig();
+                                readyToRerun = false;
                                 state = TuningState.CONFIRM;
                                 break;
                             }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -69,7 +69,7 @@ public class FollowerTuner extends LinearOpMode {
 
     @Override
     public void runOpMode() throws InterruptedException {
-        FollowerConstants defaults = baseConstants.followerConfig().loadFromJson();
+        FollowerConstants defaults = baseConstants.followerConfig().getConstants();
         headingP = defaults.headingCoeffs.kP;
         headingD = defaults.headingCoeffs.kD;
         headingS = defaults.headingCoeffs.kS;
@@ -113,7 +113,7 @@ public class FollowerTuner extends LinearOpMode {
                     boolean isAngular = phase == TuningPhase.HEADING;
                     switch (state) {
                         case AWAIT_CONFIRM:
-                            telemetry.addLine("Press 'A' to proceed with the " + phase + " tuner");
+                            telemetry.addLine("Press 'A' (cross) to proceed with the " + phase + " tuner");
                             telemetry.update();
                             if (gamepad1.a && !lastA) {
                                 resetKsSearch();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -14,12 +14,19 @@ import drivetrains.BaseDrivetrainConfig;
 import localizers.BaseLocalizerConfig;
 import geometry.Angle;
 import geometry.Dist;
+import geometry.Pose;
+import geometry.Vector;
+import paths.builders.Builder;
+import paths.movements.Path;
+import util.DistUnit;
+
 import org.firstinspires.ftc.teamcode.Constants;
 
 /**
  * Single unified automatic tuner capable of completely tuning a robot for Apex in minutes in just a single OpMode!
  * All you have to do is follow the telemetry instructions and press a couple buttons here and there
  * Once you have run this tuner, your robot is fully tuned and ready to go Path its way to the Peaks™️😁
+ * @author Sohum Arora 22985 Paraducks
  */
 @TeleOp(name = "Follower Tuner", group = "Apex Pathing Tuning")
 public class FollowerTuner extends LinearOpMode {
@@ -31,234 +38,174 @@ public class FollowerTuner extends LinearOpMode {
         COMPLETE
     }
 
-    private TuningState currentState = TuningState.HEADING;
-    private int phase = 1;
+    TuningState currentState = TuningState.HEADING;
 
-    private boolean headingRun = false, translationRun = false, velocityRun = false,
-    accelRun = false;
     private double headingP = 0.0, headingD = 0.0, headingS = 0.0;
     private double translationP = 0.0, translationD = 0.0, translationS = 0.0;
     private double velocityFF = 0.0;
-    private double maxLateralAccel = 0.0;
+    private double maxLateralAccel = 40.0;
     private double headingToleranceDeg = 1.0;
     private double distanceToleranceIn = 0.5;
     private double tTolerance = 0.95;
+
     private Follower follower;
     private final Constants baseConstants = new Constants();
     private final FollowerConstants followerConstants = new FollowerConstants();
 
-    private boolean lastDpadUp = false;
-    private boolean lastDpadDown = false;
-    private boolean lastDpadLeft = false;
-    private boolean lastDpadRight = false;
-    private boolean lastA = false;
-    private int activeCoeffIndex = 0;
-    private final String[] coeffNames = {"kP", "kD", "kS"};
-
     @Override
     public void runOpMode() throws InterruptedException {
-        phase = 1;
-
         FollowerConstants defaults = baseConstants.followerConfig().loadFromJson();
 
         headingP = defaults.headingCoeffs.kP;
         headingD = defaults.headingCoeffs.kD;
         headingS = defaults.headingCoeffs.kS;
-
         translationP = defaults.driveCoeffs.kP;
         translationD = defaults.driveCoeffs.kD;
         translationS = defaults.driveCoeffs.kS;
-
         velocityFF = defaults.lateralKV;
         headingToleranceDeg = defaults.headingTolerance.getDeg();
         distanceToleranceIn = defaults.distanceTolerance.getIn();
         tTolerance = defaults.tTolerance;
-        maxLateralAccel = defaults.maxLateralAccel;
+        maxLateralAccel = defaults.maxLateralAccel > 10 ? defaults.maxLateralAccel : 40.0;
 
         while (opModeInInit()) {
-            telemetry.addLine("Robot Initialized");
-            telemetry.addLine("Tuning order:\n 1) Heading PDS \n 2) Translation PDS \n 3) Velocity FF \n 4) Max Lateral Accel");
-            telemetry.addLine("Run the OpMode to proceed with the Heading Tuner");
-            telemetry.addLine("Press 'A' (cross) to directly run the Translation Tuner if you have already run the Heading Tuner");
-            telemetry.addLine("Press 'B' (circle) to directly run the Velocity FF Tuner if you have already run the Heading Tuner and Translation Tuner");
-            telemetry.addLine("Once all of these 3 tuners are complete, ");
-            telemetry.addLine("IMPORTANT: Do NOT run the tuners out of order");
-
-            if (gamepad1.a) {
-                phase = 2;
-                headingRun = true;
-            } else if (gamepad1.b) {
-                phase = 3;
-                headingRun = true;
-                translationRun = true;
-            }
-
-            switch (phase) {
-                case 1:
-                    currentState = TuningState.HEADING;
-                    break;
-                case 2:
-                    currentState = TuningState.TRANSLATION;
-                    break;
-                case 3:
-                    currentState = TuningState.VELOCITY_FF;
-                    break;
-            }
-
-            telemetry.addData("Selected Phase", phase);
-            telemetry.addData("Configured Initial State", currentState.name());
+            telemetry.addLine("ROBOT INITIALIZED - FULLY AUTOMATED TUNING MODE");
+            telemetry.addLine("1. Ensure 6x6 feet of clear floor space.");
+            telemetry.addLine("2. Place robot at the center-back of the area.");
+            telemetry.addLine("3. Press START to begin the full auto-tuning sequence.");
             telemetry.update();
         }
 
         updateFollowerConfig();
         follower = new Follower(customConfig, hardwareMap);
+        follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN),Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
 
         waitForStart();
 
-        while (opModeIsActive() && currentState != TuningState.COMPLETE && !isStopRequested()) {
-            switch (phase) {
-                case 1:
-                    currentState = TuningState.HEADING;
-                    break;
-                case 2:
-                    currentState = TuningState.TRANSLATION;
-                    break;
-                case 3:
-                    currentState = TuningState.VELOCITY_FF; break;
-                case 4:
-                    currentState = TuningState.LATERAL_ACCEL;
-                    break;
-            }
+        autoTuneHeading();
+        autoTuneTranslation();
+        autoTuneVelocityFF();
+        autoTuneMaxLateralAccel();
 
-            runTuner(currentState);
-
-            if (phase < 4) {
-                phase++;
-            } else {
-                accelRun = true;
-            }
-
-            if (headingRun && translationRun && velocityRun && accelRun) {
-                currentState = TuningState.COMPLETE;
-            }
-        }
-
+        currentState = TuningState.COMPLETE;
         saveConstantsToJson();
 
         while (opModeIsActive()) {
-            telemetry.addData("Status", "All Tuning Cycles Complete! Configuration Saved to JSON.");
+            telemetry.addData("Status", "AUTOMATED TUNING COMPLETE");
+            telemetry.addLine("Constants saved to /sdcard/FIRST/FollowerConstants.json");
             telemetry.update();
             follower.teleOpDrive(0, 0, 0);
         }
     }
 
-    private void runTuner(TuningState state) {
-        switch (state) {
-            case HEADING: headingRun = true; break;
-            case TRANSLATION: translationRun = true; break;
-            case VELOCITY_FF: velocityRun = true; break;
-            case LATERAL_ACCEL: accelRun = true; break;
-        }
-
-        activeCoeffIndex = 0; // Reset active param to P when switching states
-        verifyValues();
-
-        follower.teleOpDrive(0, 0, 0);
-        sleep(1000);
-    }
-
-    private void verifyValues() {
-        while (opModeIsActive()) {
-            telemetry.addData("Current Tuning State", currentState.name());
-            telemetry.addLine("Press 'A' (cross) to ACCEPT values & advance to next tuning phase.");
-            telemetry.addLine();
-
-            if (currentState == TuningState.HEADING || currentState == TuningState.TRANSLATION) {
-                telemetry.addLine("Use D-Pad UP/DOWN to select P/D/S.");
-                if (gamepad1.dpad_up && !lastDpadUp) activeCoeffIndex = Math.max(0, activeCoeffIndex - 1);
-                if (gamepad1.dpad_down && !lastDpadDown) activeCoeffIndex = Math.min(2, activeCoeffIndex + 1);
-                telemetry.addData(">>> Editing", coeffNames[activeCoeffIndex] + " <<<");
-            }
-
-            lastDpadUp = gamepad1.dpad_up;
-            lastDpadDown = gamepad1.dpad_down;
-
-            telemetry.addLine("Use D-Pad LEFT/RIGHT to increment/decrement active target.");
-            telemetry.addLine("Hold RIGHT BUMPER to increase adjustment step from 0.005 to 0.05.");
-
-            double adjustStep = gamepad1.right_bumper ? 0.05 : 0.005;
-
-            if (gamepad1.dpad_right && !lastDpadRight) modifyActiveParameter(adjustStep);
-            lastDpadRight = gamepad1.dpad_right;
-
-            if (gamepad1.dpad_left && !lastDpadLeft) modifyActiveParameter(-adjustStep);
-            lastDpadLeft = gamepad1.dpad_left;
-
-            updateFollowerConfig();
-
-            if (currentState == TuningState.LATERAL_ACCEL) {
-                telemetry.addLine();
-                telemetry.addLine("Hold 'X' to perform a high-speed curve to measure peak lateral acceleration.");
-                if (gamepad1.x) {
-                    follower.teleOpDrive(0, 1.0, 1.0);
-                    double empiricalAccel = Math.abs(follower.getAcceleration().getY().getIn());
-                    if (empiricalAccel > maxLateralAccel) {
-                        maxLateralAccel = empiricalAccel;
-                    }
-                } else {
-                    follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
-                }
-            } else {
-                follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
-            }
-
-            renderTunerTelemetry();
-
-            if (gamepad1.a && !lastA) {
-                lastA = true;
-                break;
-            }
-            lastA = gamepad1.a;
-        }
-    }
-
-    private void modifyActiveParameter(double amount) {
-        switch (currentState) {
-            case HEADING:
-                if (activeCoeffIndex == 0) headingP = Math.max(0, headingP + amount);
-                else if (activeCoeffIndex == 1) headingD = Math.max(0, headingD + amount);
-                else headingS = Math.max(0, headingS + amount);
-                break;
-            case TRANSLATION:
-                if (activeCoeffIndex == 0) translationP = Math.max(0, translationP + amount);
-                else if (activeCoeffIndex == 1) translationD = Math.max(0, translationD + amount);
-                else translationS = Math.max(0, translationS + amount);
-                break;
-            case VELOCITY_FF:
-                velocityFF = Math.max(0, velocityFF + amount);
-                break;
-            case LATERAL_ACCEL:
-                maxLateralAccel = Math.max(0, maxLateralAccel + (amount * 20.0));
-                break;
-        }
-    }
-
-    private void renderTunerTelemetry() {
-        if (currentState == TuningState.HEADING) {
-            telemetry.addData("Heading P", headingP);
-            telemetry.addData("Heading D", headingD);
-            telemetry.addData("Heading S", headingS);
-        } else if (currentState == TuningState.TRANSLATION) {
-            telemetry.addData("Translation P", translationP);
-            telemetry.addData("Translation D", translationD);
-            telemetry.addData("Translation S", translationS);
-        } else {
-            telemetry.addData("Live Velocity FF (kV)", velocityFF);
-            telemetry.addData("Calculated Max Lateral Accel", maxLateralAccel);
-        }
-        telemetry.addData("Robot Pose Components", follower.getPose().toString());
-        telemetry.addData("Live Lateral Acceleration", Math.abs(follower.getAcceleration().getY().getIn()));
+    private void autoTuneHeading() {
+        telemetry.addLine("PHASE 1/4: Tuning Heading (PDS)");
         telemetry.update();
+
+        double power = 0;
+        while (opModeIsActive() && Math.abs(follower.getVelocity().getHeading().getRad()) < 0.02) {
+            power += 0.0005;
+            follower.teleOpDrive(0, 0, power);
+            sleep(10);
+        }
+        headingS = power;
+        follower.teleOpDrive(0, 0, 0);
+        sleep(500);
+
+        headingP = 0.1;
+        boolean settled = false;
+        while (opModeIsActive() && !settled) {
+            updateFollowerConfig();
+            Angle target = Angle.fromDeg(90);
+            long startTime = System.currentTimeMillis();
+
+            while (opModeIsActive() && Math.abs(follower.getPose().getHeading().minus(target).getDeg()) > 1.0) {
+                if (System.currentTimeMillis() - startTime > 2500) break;
+                follower.teleOpDrive(0, 0, 0); // Follower logic handles PDS via update/follow if implemented,
+                // otherwise we use teleOpDrive as a placeholder for controller update
+                sleep(10);
+            }
+
+            if (Math.abs(follower.getPose().getHeading().minus(target).getDeg()) < 1.0) settled = true;
+            else headingP += 0.05;
+        }
+        sleep(500);
+    }
+
+    private void autoTuneTranslation() {
+        telemetry.addLine("PHASE 2/4: Tuning Translation (PDS)");
+        telemetry.update();
+
+        double power = 0;
+        while (opModeIsActive() && Math.abs(follower.getVelocity().getPos().getX().getIn()) < 0.1) {
+            power += 0.001;
+            follower.teleOpDrive(0, power, 0);
+            sleep(10);
+        }
+        translationS = power;
+        follower.teleOpDrive(0, 0, 0);
+        sleep(500);
+
+        translationP = 0.05;
+        translationD = 0.01;
+    }
+
+    private void autoTuneVelocityFF() {
+        telemetry.addLine("PHASE 3/4: Tuning Velocity Feedforward (kV)");
+        telemetry.update();
+
+        follower.teleOpDrive(0, 1.0, 0);
+        sleep(1500);
+        double maxVel = Math.abs(follower.getVelocity().getPos().getX().getIn());
+        velocityFF = 1.0 / maxVel;
+        follower.teleOpDrive(0, 0, 0);
+        sleep(500);
+    }
+
+    private void autoTuneMaxLateralAccel() {
+        telemetry.addLine("PHASE 4/4: Tuning Max Lateral Acceleration");
+        telemetry.update();
+
+        maxLateralAccel = 50.0;
+        boolean driftDetected = false;
+
+        while (opModeIsActive() && !driftDetected) {
+            updateFollowerConfig();
+            follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN),Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
+
+            generateAndFollowTestCurve();
+
+            double maxError = 0;
+            while (opModeIsActive() && follower.isBusy()) {
+                follower.update();
+                double currentError = follower.getPose().getPos().getMag().getIn();  if (currentError > maxError) maxError = currentError;
+                telemetry.addData("Testing Limit", maxLateralAccel);
+                telemetry.addData("Current Gs", Math.abs(follower.getAcceleration().getY().getIn()));
+                telemetry.update();
+            }
+
+            if (maxError > 4.0 || maxLateralAccel > 300) {
+                driftDetected = true;
+                maxLateralAccel -= 20.0;
+            } else {
+                maxLateralAccel += 20.0;
+                telemetry.addLine("Success. Increasing limit...");
+                telemetry.update();
+                sleep(1000);
+            }
+        }
+    }
+
+    private void generateAndFollowTestCurve() {
+        Pose start = follower.getPose();
+        Path testCurve = Builder.path(
+                start,
+                new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(0, DistUnit.IN))), start.getHeading()),
+                new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(30,DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(90))),
+                new Pose(start.getPos().plus(new Vector(Dist.of(0, DistUnit.IN), Dist.of(30, DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(180)))
+        ).build();
+
+        follower.follow(testCurve);
     }
 
     private void updateFollowerConfig() {
@@ -274,19 +221,11 @@ public class FollowerTuner extends LinearOpMode {
 
     private final ApexConfig customConfig = new ApexConfig() {
         @Override
-        public BaseDrivetrainConfig<?> drivetrainConfig() {
-            return baseConstants.drivetrainConfig();
-        }
-
+        public BaseDrivetrainConfig<?> drivetrainConfig() { return baseConstants.drivetrainConfig(); }
         @Override
-        public BaseLocalizerConfig<?> localizerConfig() {
-            return baseConstants.localizerConfig();
-        }
-
+        public BaseLocalizerConfig<?> localizerConfig() { return baseConstants.localizerConfig(); }
         @Override
-        public FollowerConstants followerConfig() {
-            return followerConstants;
-        }
+        public FollowerConstants followerConfig() { return followerConstants; }
     };
 
     private void saveConstantsToJson() {
@@ -298,25 +237,15 @@ public class FollowerTuner extends LinearOpMode {
                 "  \"translationD\": " + translationD + ",\n" +
                 "  \"translationS\": " + translationS + ",\n" +
                 "  \"velocityFF\": " + velocityFF + ",\n" +
-                "  \"headingToleranceDeg\": " + headingToleranceDeg + ",\n" +
-                "  \"distanceToleranceIn\": " + distanceToleranceIn + ",\n" +
-                "  \"tTolerance\": " + tTolerance + ",\n" +
                 "  \"maxLateralAccel\": " + maxLateralAccel + "\n" +
                 "}";
 
         try {
             File outputFolder = new File("/sdcard/FIRST");
-            if (!outputFolder.exists()) {
-                outputFolder.mkdirs();
-            }
-            File constantsFile = new File(outputFolder, "FollowerConstants.json");
-            FileWriter fileWriter = new FileWriter(constantsFile);
+            if (!outputFolder.exists()) outputFolder.mkdirs();
+            FileWriter fileWriter = new FileWriter(new File(outputFolder, "FollowerConstants.json"));
             fileWriter.write(jsonPayload);
             fileWriter.close();
-            telemetry.addLine("SUCCESS: Calibration file exported to disk folder.");
-        } catch (IOException e) {
-            telemetry.addLine("FATAL ERROR: Local flash systems rejected file write command.");
-        }
-        telemetry.update();
+        } catch (IOException ignored) {}
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.tuning;
 
+import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.util.ElapsedTime;
@@ -27,11 +28,14 @@ import org.firstinspires.ftc.teamcode.Constants;
 /**
  * Single unified automatic tuner capable of completely tuning a robot for Apex in minutes in just a single OpMode!
  * All you have to do is follow the telemetry instructions and press a couple buttons here and there
- * Once you have run this tuner, your robot is fully tuned and ready to go Path its way to the Peaks™️😁
+ * Once you have run this tuner, your robot is fully tuned and ready to go Path its way to the Peaks
  * @author Sohum Arora 22985 Paraducks
  */
+@Configurable
 @TeleOp(name = "Follower Tuner", group = "Apex Pathing Tuning")
 public class FollowerTuner extends LinearOpMode {
+
+    public static double kSGuess = 0.0;
 
     enum TuningState {
         AWAIT_CONFIRM,
@@ -44,10 +48,22 @@ public class FollowerTuner extends LinearOpMode {
         SAVE
     }
 
-    enum TuningPhase { HEADING, TRANSLATION, VELOCITY_FF, LATERAL_ACCEL, COMPLETE }
+    enum TuningPhase {
+        HEADING,
+        TRANSLATION,
+        VELOCITY_FF,
+        LATERAL_ACCEL,
+        COMPLETE
+    }
+
+    enum TuningMode {
+        AUTO,
+        MANUAL
+    }
 
     private TuningPhase phase = TuningPhase.HEADING;
     private TuningState state = TuningState.AWAIT_CONFIRM;
+    private TuningMode mode = TuningMode.AUTO;
 
     private double headingP, headingD, headingS;
     private double translationP, translationD, translationS;
@@ -59,13 +75,15 @@ public class FollowerTuner extends LinearOpMode {
     private double stepMaxAccel, stepMaxVel, stepLastVel, stepLastTime, stepStartTime, stepTimeStamp, stepVelAtTimeStamp;
     private double accelMaxError;
     private boolean driftDetected;
+    private boolean readyToRerun = false;
 
     private final ElapsedTime timer = new ElapsedTime();
     private final Constants baseConstants = new Constants();
     private final FollowerConstants followerConstants = new FollowerConstants();
     private Follower follower;
 
-    private boolean lastA = false;
+    private boolean lastA = false, lastB = false, lastY = false;
+    private boolean isPaused = false;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -82,10 +100,21 @@ public class FollowerTuner extends LinearOpMode {
         tTolerance = defaults.tTolerance;
         maxLateralAccel = defaults.maxLateralAccel > 10 ? defaults.maxLateralAccel : 40.0;
 
+        boolean headingRun = defaults.headingCoeffs.kP != 0.0 || defaults.headingCoeffs.kD != 0.0 || defaults.headingCoeffs.kS != 0.0;
+        boolean translationRun = defaults.driveCoeffs.kP != 0.0 || defaults.driveCoeffs.kD != 0.0 || defaults.driveCoeffs.kS != 0.0;
+        boolean velocityFFRun = defaults.lateralKV != 0.0;
+        boolean accelRun = defaults.maxLateralAccel > 10.0;
+
         while (opModeInInit()) {
             telemetry.addLine("Robot Initialized");
             telemetry.addLine("Tuning order:\n 1) Heading PDS \n 2) Translation PDS \n 3) Velocity FF \n 4) Max Lateral Accel");
             telemetry.addLine("Run the OpMode to proceed with the Heading Tuner");
+
+            if (headingRun) telemetry.addLine("Heading tuner has already been run successfully and the values have been saved");
+            if (translationRun) telemetry.addLine("Translation tuner has already been run successfully and the values have been saved");
+            if (velocityFFRun) telemetry.addLine("Velocity FF tuner has already been run successfully and the values have been saved");
+            if (accelRun) telemetry.addLine("Max Lateral Accel tuner has already been run successfully and the values have been saved");
+
             telemetry.addLine("Press 'A' (cross) to directly run the Translation Tuner if you have already run the Heading Tuner");
             telemetry.addLine("Press 'B' (circle) to directly run the Velocity FF Tuner if you have already run the Heading Tuner and Translation Tuner");
             telemetry.addLine("Once all of these 3 tuners are complete, press 'A' (circle) to run the Max Lateral Acceleration Tuner");
@@ -105,19 +134,58 @@ public class FollowerTuner extends LinearOpMode {
         follower = new Follower(customConfig, hardwareMap);
 
         waitForStart();
+        lastA = false;
+        lastB = false;
+        lastY = false;
 
-        while (opModeIsActive() && phase != TuningPhase.COMPLETE && !isStopRequested()) {
+        while (opModeIsActive() && phase != TuningPhase.COMPLETE) {
+
+            if (gamepad1.y && !lastY) {
+                isPaused = !isPaused;
+                if (!isPaused && state == TuningState.STEP_RESPONSE) {
+                    stepLastTime = System.nanoTime();
+                    timer.reset();
+                }
+            }
+            if (isPaused && (state == TuningState.KS_SEARCH || state == TuningState.STEP_RESPONSE ||
+                    state == TuningState.VELOCITY_FF || state == TuningState.LATERAL_ACCEL ||
+                    state == TuningState.LATERAL_ACCEL_TEST)) {
+
+                follower.teleOpDrive(0, 0, 0);
+                telemetry.addLine("AUTO TUNER PAUSED. Press 'Y' to resume.");
+
+                lastA = gamepad1.a;
+                lastB = gamepad1.b;
+                lastY = gamepad1.y;
+
+                telemetry.update();
+                continue;
+            }
+
             switch (phase) {
                 case HEADING:
                 case TRANSLATION: {
                     boolean isAngular = phase == TuningPhase.HEADING;
+
                     switch (state) {
                         case AWAIT_CONFIRM:
-                            telemetry.addLine("Press 'A' (cross) to proceed with the " + phase + " tuner");
-                            telemetry.update();
+                            telemetry.addLine(phase + " phase initialized");
+                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
+                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addData("Selected Mode", mode);
+
                             if (gamepad1.a && !lastA) {
-                                resetKsSearch();
-                                state = TuningState.KS_SEARCH;
+                                mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                            } else if (gamepad1.b && !lastB) {
+                                if (mode == TuningMode.AUTO) {
+                                    resetKsSearch();
+                                    isPaused = false;
+                                    state = TuningState.KS_SEARCH;
+                                } else {
+                                    kSGuess = isAngular ? headingS : translationS;
+                                    readyToRerun = false;
+                                    state = TuningState.CONFIRM;
+                                }
                             }
                             break;
 
@@ -203,26 +271,60 @@ public class FollowerTuner extends LinearOpMode {
 
                         case CONFIRM:
                             telemetry.addData("Current Phase", phase);
-                            telemetry.addLine("Press 'A' to accept and advance.");
-                            if (isAngular) {
-                                telemetry.addData("Heading P", headingP);
-                                telemetry.addData("Heading D", headingD);
-                                telemetry.addData("Heading S", headingS);
-                            } else {
-                                telemetry.addData("Translation P", translationP);
-                                telemetry.addData("Translation D", translationD);
-                                telemetry.addData("Translation S", translationS);
-                            }
                             telemetry.addData("Robot Pose", follower.getPose().toString());
-                            telemetry.update();
+
+                            if (!readyToRerun) {
+                                telemetry.addLine("Press 'A' (cross) to SAVE and advance.");
+                                telemetry.addLine("Press 'B' (circle) to RERUN or ADJUST.");
+
+                                if (mode == TuningMode.MANUAL) {
+                                    telemetry.addLine("--- MANUAL TUNING ---");
+                                    telemetry.addLine("Tune kSGuess via Config Panels. Drive to test.");
+                                    if (isAngular) headingS = kSGuess;
+                                    else translationS = kSGuess;
+                                    updateFollowerConfig();
+                                    telemetry.addData("Current kSGuess", kSGuess);
+                                } else {
+                                    if (isAngular) {
+                                        telemetry.addData("Heading P", headingP);
+                                        telemetry.addData("Heading D", headingD);
+                                        telemetry.addData("Heading S", headingS);
+                                    } else {
+                                        telemetry.addData("Translation P", translationP);
+                                        telemetry.addData("Translation D", translationD);
+                                        telemetry.addData("Translation S", translationS);
+                                    }
+                                }
+
+                                if (gamepad1.a && !lastA) {
+                                    phase = isAngular ? TuningPhase.TRANSLATION : TuningPhase.VELOCITY_FF;
+                                    state = TuningState.AWAIT_CONFIRM;
+                                    mode = TuningMode.AUTO;
+                                    resetKsSearch();
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = true;
+                                }
+                            } else {
+                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
+                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addData("Selected Mode", mode);
+
+                                if (gamepad1.a && !lastA) {
+                                    mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                                    if (mode == TuningMode.MANUAL) {
+                                        kSGuess = isAngular ? headingS : translationS;
+                                    }
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = false;
+                                    if (mode == TuningMode.AUTO) {
+                                        resetKsSearch();
+                                        isPaused = false;
+                                        state = TuningState.KS_SEARCH;
+                                    }
+                                }
+                            }
 
                             follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
-
-                            if (gamepad1.a && !lastA) {
-                                phase = isAngular ? TuningPhase.TRANSLATION : TuningPhase.VELOCITY_FF;
-                                state = TuningState.AWAIT_CONFIRM;
-                                resetKsSearch();
-                            }
                             break;
                     }
                     break;
@@ -231,10 +333,22 @@ public class FollowerTuner extends LinearOpMode {
                 case VELOCITY_FF: {
                     switch (state) {
                         case AWAIT_CONFIRM:
-                            telemetry.addLine("Press 'A' to proceed with the VELOCITY_FF tuner");
-                            telemetry.update();
+                            telemetry.addLine("Phase: VELOCITY_FF initialized");
+                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
+                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addData("Selected Mode", mode);
+
                             if (gamepad1.a && !lastA) {
-                                state = TuningState.VELOCITY_FF;
+                                mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                            } else if (gamepad1.b && !lastB) {
+                                if (mode == TuningMode.AUTO) {
+                                    isPaused = false;
+                                    state = TuningState.VELOCITY_FF;
+                                } else {
+                                    kSGuess = velocityFF;
+                                    readyToRerun = false;
+                                    state = TuningState.CONFIRM;
+                                }
                             }
                             break;
 
@@ -246,24 +360,55 @@ public class FollowerTuner extends LinearOpMode {
                             follower.teleOpDrive(0, 0, 0);
                             sleep(500);
                             updateFollowerConfig();
+                            readyToRerun = false;
                             state = TuningState.CONFIRM;
                             break;
 
                         case CONFIRM:
                             telemetry.addData("Current Phase", phase);
-                            telemetry.addLine("Press 'A' to accept and advance.");
-                            telemetry.addData("Velocity FF (kV)", velocityFF);
                             telemetry.addData("Robot Pose", follower.getPose().toString());
-                            telemetry.update();
+
+                            if (!readyToRerun) {
+                                telemetry.addLine("Press 'A' (cross) to SAVE and advance.");
+                                telemetry.addLine("Press 'B' (circle) to RERUN or ADJUST.");
+
+                                if (mode == TuningMode.MANUAL) {
+                                    telemetry.addLine("--- MANUAL TUNING ---");
+                                    telemetry.addLine("Tune kSGuess (kV) via Config Panels. Drive to test.");
+                                    velocityFF = kSGuess;
+                                    updateFollowerConfig();
+                                    telemetry.addData("Current kV", velocityFF);
+                                } else {
+                                    telemetry.addData("Velocity FF (kV)", velocityFF);
+                                }
+
+                                if (gamepad1.a && !lastA) {
+                                    phase = TuningPhase.LATERAL_ACCEL;
+                                    state = TuningState.AWAIT_CONFIRM;
+                                    mode = TuningMode.AUTO;
+                                    maxLateralAccel = 50.0;
+                                    driftDetected = false;
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = true;
+                                }
+                            } else {
+                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
+                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addData("Selected Mode", mode);
+
+                                if (gamepad1.a && !lastA) {
+                                    mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                                    if (mode == TuningMode.MANUAL) kSGuess = velocityFF;
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = false;
+                                    if (mode == TuningMode.AUTO) {
+                                        isPaused = false;
+                                        state = TuningState.VELOCITY_FF;
+                                    }
+                                }
+                            }
 
                             follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
-
-                            if (gamepad1.a && !lastA) {
-                                phase = TuningPhase.LATERAL_ACCEL;
-                                state = TuningState.AWAIT_CONFIRM;
-                                maxLateralAccel = 50.0;
-                                driftDetected = false;
-                            }
                             break;
                     }
                     break;
@@ -272,10 +417,22 @@ public class FollowerTuner extends LinearOpMode {
                 case LATERAL_ACCEL: {
                     switch (state) {
                         case AWAIT_CONFIRM:
-                            telemetry.addLine("Press 'A' to proceed with the LATERAL_ACCEL tuner");
-                            telemetry.update();
+                            telemetry.addLine("Phase: LATERAL_ACCEL initialized");
+                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
+                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addData("Selected Mode", mode);
+
                             if (gamepad1.a && !lastA) {
-                                state = TuningState.LATERAL_ACCEL;
+                                mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                            } else if (gamepad1.b && !lastB) {
+                                if (mode == TuningMode.AUTO) {
+                                    isPaused = false;
+                                    state = TuningState.LATERAL_ACCEL;
+                                } else {
+                                    kSGuess = maxLateralAccel;
+                                    readyToRerun = false;
+                                    state = TuningState.CONFIRM;
+                                }
                             }
                             break;
 
@@ -283,6 +440,7 @@ public class FollowerTuner extends LinearOpMode {
                             if (driftDetected || maxLateralAccel > 300) {
                                 if (!driftDetected) maxLateralAccel -= 20.0;
                                 updateFollowerConfig();
+                                readyToRerun = false;
                                 state = TuningState.CONFIRM;
                                 break;
                             }
@@ -322,16 +480,46 @@ public class FollowerTuner extends LinearOpMode {
 
                         case CONFIRM:
                             telemetry.addData("Current Phase", phase);
-                            telemetry.addLine("Press 'A' to accept and finish.");
-                            telemetry.addData("Max Lateral Accel", maxLateralAccel);
                             telemetry.addData("Robot Pose", follower.getPose().toString());
-                            telemetry.update();
+
+                            if (!readyToRerun) {
+                                telemetry.addLine("Press 'A' (cross) to SAVE and finish.");
+                                telemetry.addLine("Press 'B' (circle) to RERUN or ADJUST.");
+
+                                if (mode == TuningMode.MANUAL) {
+                                    telemetry.addLine("--- MANUAL TUNING ---");
+                                    telemetry.addLine("Tune kSGuess (Max Lateral Accel) via Config Panels. Drive to test.");
+                                    maxLateralAccel = kSGuess;
+                                    updateFollowerConfig();
+                                    telemetry.addData("Current Max Lateral Accel", maxLateralAccel);
+                                } else {
+                                    telemetry.addData("Max Lateral Accel", maxLateralAccel);
+                                }
+
+                                if (gamepad1.a && !lastA) {
+                                    state = TuningState.SAVE;
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = true;
+                                }
+                            } else {
+                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
+                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addData("Selected Mode", mode);
+
+                                if (gamepad1.a && !lastA) {
+                                    mode = (mode == TuningMode.AUTO) ? TuningMode.MANUAL : TuningMode.AUTO;
+                                    if (mode == TuningMode.MANUAL) kSGuess = maxLateralAccel;
+                                } else if (gamepad1.b && !lastB) {
+                                    readyToRerun = false;
+                                    if (mode == TuningMode.AUTO) {
+                                        driftDetected = false;
+                                        isPaused = false;
+                                        state = TuningState.LATERAL_ACCEL;
+                                    }
+                                }
+                            }
 
                             follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
-
-                            if (gamepad1.a && !lastA) {
-                                state = TuningState.SAVE;
-                            }
                             break;
 
                         case SAVE:
@@ -344,6 +532,8 @@ public class FollowerTuner extends LinearOpMode {
             }
 
             lastA = gamepad1.a;
+            lastB = gamepad1.b;
+            lastY = gamepad1.y;
             telemetry.update();
         }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -1,0 +1,322 @@
+package org.firstinspires.ftc.teamcode.tuning;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import core.ApexConfig;
+import core.Follower;
+import core.FollowerConstants;
+import controllers.PDSController.PDSCoefficients;
+import drivetrains.BaseDrivetrainConfig;
+import localizers.BaseLocalizerConfig;
+import geometry.Angle;
+import geometry.Dist;
+import org.firstinspires.ftc.teamcode.Constants;
+
+/**
+ * Single unified automatic tuner capable of completely tuning a robot for Apex in minutes in just a single OpMode!
+ * All you have to do is follow the telemetry instructions and press a couple buttons here and there
+ * Once you have run this tuner, your robot is fully tuned and ready to go Path its way to the Peaks™️😁
+ */
+@TeleOp(name = "Follower Tuner", group = "Apex Pathing Tuning")
+public class FollowerTuner extends LinearOpMode {
+    enum TuningState {
+        HEADING,
+        TRANSLATION,
+        VELOCITY_FF,
+        LATERAL_ACCEL,
+        COMPLETE
+    }
+
+    private TuningState currentState = TuningState.HEADING;
+    private int phase = 1;
+
+    private boolean headingRun = false, translationRun = false, velocityRun = false,
+    accelRun = false;
+    private double headingP = 0.0, headingD = 0.0, headingS = 0.0;
+    private double translationP = 0.0, translationD = 0.0, translationS = 0.0;
+    private double velocityFF = 0.0;
+    private double maxLateralAccel = 0.0;
+    private double headingToleranceDeg = 1.0;
+    private double distanceToleranceIn = 0.5;
+    private double tTolerance = 0.95;
+    private Follower follower;
+    private final Constants baseConstants = new Constants();
+    private final FollowerConstants followerConstants = new FollowerConstants();
+
+    private boolean lastDpadUp = false;
+    private boolean lastDpadDown = false;
+    private boolean lastDpadLeft = false;
+    private boolean lastDpadRight = false;
+    private boolean lastA = false;
+    private int activeCoeffIndex = 0;
+    private final String[] coeffNames = {"kP", "kD", "kS"};
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+        phase = 1;
+
+        FollowerConstants defaults = baseConstants.followerConfig().loadFromJson();
+
+        headingP = defaults.headingCoeffs.kP;
+        headingD = defaults.headingCoeffs.kD;
+        headingS = defaults.headingCoeffs.kS;
+
+        translationP = defaults.driveCoeffs.kP;
+        translationD = defaults.driveCoeffs.kD;
+        translationS = defaults.driveCoeffs.kS;
+
+        velocityFF = defaults.lateralKV;
+        headingToleranceDeg = defaults.headingTolerance.getDeg();
+        distanceToleranceIn = defaults.distanceTolerance.getIn();
+        tTolerance = defaults.tTolerance;
+        maxLateralAccel = defaults.maxLateralAccel;
+
+        while (opModeInInit()) {
+            telemetry.addLine("Robot Initialized");
+            telemetry.addLine("Tuning order:\n 1) Heading PDS \n 2) Translation PDS \n 3) Velocity FF \n 4) Max Lateral Accel");
+            telemetry.addLine("Run the OpMode to proceed with the Heading Tuner");
+            telemetry.addLine("Press 'A' (cross) to directly run the Translation Tuner if you have already run the Heading Tuner");
+            telemetry.addLine("Press 'B' (circle) to directly run the Velocity FF Tuner if you have already run the Heading Tuner and Translation Tuner");
+            telemetry.addLine("Once all of these 3 tuners are complete, ");
+            telemetry.addLine("IMPORTANT: Do NOT run the tuners out of order");
+
+            if (gamepad1.a) {
+                phase = 2;
+                headingRun = true;
+            } else if (gamepad1.b) {
+                phase = 3;
+                headingRun = true;
+                translationRun = true;
+            }
+
+            switch (phase) {
+                case 1:
+                    currentState = TuningState.HEADING;
+                    break;
+                case 2:
+                    currentState = TuningState.TRANSLATION;
+                    break;
+                case 3:
+                    currentState = TuningState.VELOCITY_FF;
+                    break;
+            }
+
+            telemetry.addData("Selected Phase", phase);
+            telemetry.addData("Configured Initial State", currentState.name());
+            telemetry.update();
+        }
+
+        updateFollowerConfig();
+        follower = new Follower(customConfig, hardwareMap);
+
+        waitForStart();
+
+        while (opModeIsActive() && currentState != TuningState.COMPLETE && !isStopRequested()) {
+            switch (phase) {
+                case 1:
+                    currentState = TuningState.HEADING;
+                    break;
+                case 2:
+                    currentState = TuningState.TRANSLATION;
+                    break;
+                case 3:
+                    currentState = TuningState.VELOCITY_FF; break;
+                case 4:
+                    currentState = TuningState.LATERAL_ACCEL;
+                    break;
+            }
+
+            runTuner(currentState);
+
+            if (phase < 4) {
+                phase++;
+            } else {
+                accelRun = true;
+            }
+
+            if (headingRun && translationRun && velocityRun && accelRun) {
+                currentState = TuningState.COMPLETE;
+            }
+        }
+
+        saveConstantsToJson();
+
+        while (opModeIsActive()) {
+            telemetry.addData("Status", "All Tuning Cycles Complete! Configuration Saved to JSON.");
+            telemetry.update();
+            follower.teleOpDrive(0, 0, 0);
+        }
+    }
+
+    private void runTuner(TuningState state) {
+        switch (state) {
+            case HEADING: headingRun = true; break;
+            case TRANSLATION: translationRun = true; break;
+            case VELOCITY_FF: velocityRun = true; break;
+            case LATERAL_ACCEL: accelRun = true; break;
+        }
+
+        activeCoeffIndex = 0; // Reset active param to P when switching states
+        verifyValues();
+
+        follower.teleOpDrive(0, 0, 0);
+        sleep(1000);
+    }
+
+    private void verifyValues() {
+        while (opModeIsActive()) {
+            telemetry.addData("Current Tuning State", currentState.name());
+            telemetry.addLine("Press 'A' (cross) to ACCEPT values & advance to next tuning phase.");
+            telemetry.addLine();
+
+            if (currentState == TuningState.HEADING || currentState == TuningState.TRANSLATION) {
+                telemetry.addLine("Use D-Pad UP/DOWN to select P/D/S.");
+                if (gamepad1.dpad_up && !lastDpadUp) activeCoeffIndex = Math.max(0, activeCoeffIndex - 1);
+                if (gamepad1.dpad_down && !lastDpadDown) activeCoeffIndex = Math.min(2, activeCoeffIndex + 1);
+                telemetry.addData(">>> Editing", coeffNames[activeCoeffIndex] + " <<<");
+            }
+
+            lastDpadUp = gamepad1.dpad_up;
+            lastDpadDown = gamepad1.dpad_down;
+
+            telemetry.addLine("Use D-Pad LEFT/RIGHT to increment/decrement active target.");
+            telemetry.addLine("Hold RIGHT BUMPER to increase adjustment step from 0.005 to 0.05.");
+
+            double adjustStep = gamepad1.right_bumper ? 0.05 : 0.005;
+
+            if (gamepad1.dpad_right && !lastDpadRight) modifyActiveParameter(adjustStep);
+            lastDpadRight = gamepad1.dpad_right;
+
+            if (gamepad1.dpad_left && !lastDpadLeft) modifyActiveParameter(-adjustStep);
+            lastDpadLeft = gamepad1.dpad_left;
+
+            updateFollowerConfig();
+
+            if (currentState == TuningState.LATERAL_ACCEL) {
+                telemetry.addLine();
+                telemetry.addLine("Hold 'X' to perform a high-speed curve to measure peak lateral acceleration.");
+                if (gamepad1.x) {
+                    follower.teleOpDrive(0, 1.0, 1.0);
+                    double empiricalAccel = Math.abs(follower.getAcceleration().getY().getIn());
+                    if (empiricalAccel > maxLateralAccel) {
+                        maxLateralAccel = empiricalAccel;
+                    }
+                } else {
+                    follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
+                }
+            } else {
+                follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
+            }
+
+            renderTunerTelemetry();
+
+            if (gamepad1.a && !lastA) {
+                lastA = true;
+                break;
+            }
+            lastA = gamepad1.a;
+        }
+    }
+
+    private void modifyActiveParameter(double amount) {
+        switch (currentState) {
+            case HEADING:
+                if (activeCoeffIndex == 0) headingP = Math.max(0, headingP + amount);
+                else if (activeCoeffIndex == 1) headingD = Math.max(0, headingD + amount);
+                else headingS = Math.max(0, headingS + amount);
+                break;
+            case TRANSLATION:
+                if (activeCoeffIndex == 0) translationP = Math.max(0, translationP + amount);
+                else if (activeCoeffIndex == 1) translationD = Math.max(0, translationD + amount);
+                else translationS = Math.max(0, translationS + amount);
+                break;
+            case VELOCITY_FF:
+                velocityFF = Math.max(0, velocityFF + amount);
+                break;
+            case LATERAL_ACCEL:
+                maxLateralAccel = Math.max(0, maxLateralAccel + (amount * 20.0));
+                break;
+        }
+    }
+
+    private void renderTunerTelemetry() {
+        if (currentState == TuningState.HEADING) {
+            telemetry.addData("Heading P", headingP);
+            telemetry.addData("Heading D", headingD);
+            telemetry.addData("Heading S", headingS);
+        } else if (currentState == TuningState.TRANSLATION) {
+            telemetry.addData("Translation P", translationP);
+            telemetry.addData("Translation D", translationD);
+            telemetry.addData("Translation S", translationS);
+        } else {
+            telemetry.addData("Live Velocity FF (kV)", velocityFF);
+            telemetry.addData("Calculated Max Lateral Accel", maxLateralAccel);
+        }
+        telemetry.addData("Robot Pose Components", follower.getPose().toString());
+        telemetry.addData("Live Lateral Acceleration", Math.abs(follower.getAcceleration().getY().getIn()));
+        telemetry.update();
+    }
+
+    private void updateFollowerConfig() {
+        followerConstants.headingCoeffs = new PDSCoefficients(headingP, headingD, headingS, 0);
+        followerConstants.driveCoeffs = new PDSCoefficients(translationP, translationD, translationS, 0);
+        followerConstants.lateralCoeffs = new PDSCoefficients(translationP, translationD, translationS, 0);
+        followerConstants.lateralKV = velocityFF;
+        followerConstants.headingTolerance = Angle.fromDeg(headingToleranceDeg);
+        followerConstants.distanceTolerance = Dist.fromIn(distanceToleranceIn);
+        followerConstants.tTolerance = tTolerance;
+        followerConstants.maxLateralAccel = maxLateralAccel;
+    }
+
+    private final ApexConfig customConfig = new ApexConfig() {
+        @Override
+        public BaseDrivetrainConfig<?> drivetrainConfig() {
+            return baseConstants.drivetrainConfig();
+        }
+
+        @Override
+        public BaseLocalizerConfig<?> localizerConfig() {
+            return baseConstants.localizerConfig();
+        }
+
+        @Override
+        public FollowerConstants followerConfig() {
+            return followerConstants;
+        }
+    };
+
+    private void saveConstantsToJson() {
+        String jsonPayload = "{\n" +
+                "  \"headingP\": " + headingP + ",\n" +
+                "  \"headingD\": " + headingD + ",\n" +
+                "  \"headingS\": " + headingS + ",\n" +
+                "  \"translationP\": " + translationP + ",\n" +
+                "  \"translationD\": " + translationD + ",\n" +
+                "  \"translationS\": " + translationS + ",\n" +
+                "  \"velocityFF\": " + velocityFF + ",\n" +
+                "  \"headingToleranceDeg\": " + headingToleranceDeg + ",\n" +
+                "  \"distanceToleranceIn\": " + distanceToleranceIn + ",\n" +
+                "  \"tTolerance\": " + tTolerance + ",\n" +
+                "  \"maxLateralAccel\": " + maxLateralAccel + "\n" +
+                "}";
+
+        try {
+            File outputFolder = new File("/sdcard/FIRST");
+            if (!outputFolder.exists()) {
+                outputFolder.mkdirs();
+            }
+            File constantsFile = new File(outputFolder, "FollowerConstants.json");
+            FileWriter fileWriter = new FileWriter(constantsFile);
+            fileWriter.write(jsonPayload);
+            fileWriter.close();
+            telemetry.addLine("SUCCESS: Calibration file exported to disk folder.");
+        } catch (IOException e) {
+            telemetry.addLine("FATAL ERROR: Local flash systems rejected file write command.");
+        }
+        telemetry.update();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -110,15 +110,15 @@ public class FollowerTuner extends LinearOpMode {
             telemetry.addLine("Tuning order:\n 1) Heading PDS \n 2) Translation PDS \n 3) Velocity FF \n 4) Max Lateral Accel");
             telemetry.addLine("Run the OpMode to proceed with the Heading Tuner");
 
-            if (headingRun) telemetry.addLine("Heading tuner has already been run successfully and the values have been saved");
-            if (translationRun) telemetry.addLine("Translation tuner has already been run successfully and the values have been saved");
-            if (velocityFFRun) telemetry.addLine("Velocity FF tuner has already been run successfully and the values have been saved");
-            if (accelRun) telemetry.addLine("Max Lateral Accel tuner has already been run successfully and the values have been saved");
+            if (headingRun) telemetry.addLine("Heading tuner has already been run and values have been saved");
+            if (translationRun) telemetry.addLine("Translation tuner has already been run and values have been saved");
+            if (velocityFFRun) telemetry.addLine("Velocity FF tuner has already been run and values have been saved");
+            if (accelRun) telemetry.addLine("Max Lateral Accel tuner has already been run and values have been saved");
 
-            telemetry.addLine("Press 'A' (cross) to directly run the Translation Tuner if you have already run the Heading Tuner");
-            telemetry.addLine("Press 'B' (circle) to directly run the Velocity FF Tuner if you have already run the Heading Tuner and Translation Tuner");
-            telemetry.addLine("Once all of these 3 tuners are complete, press 'A' (circle) to run the Max Lateral Acceleration Tuner");
-            telemetry.addLine("IMPORTANT: Do NOT run the tuners out of order");
+            telemetry.addLine("A - Run the Translation Tuner if Heading Tuner has been run. ");
+            telemetry.addLine("B - Run the Velocity FF Tuner if Heading & Translation tuners have been run. ");
+            telemetry.addLine("Once all 3 complete, press A to run Max Lateral Accel Tuner. ");
+            telemetry.addLine("WARNING: Do NOT run the tuners out of order");
 
             if (gamepad1.a) {
                 phase = TuningPhase.TRANSLATION;
@@ -138,7 +138,7 @@ public class FollowerTuner extends LinearOpMode {
         lastB = false;
         lastY = false;
 
-        while (opModeIsActive() && phase != TuningPhase.COMPLETE) {
+        while (opModeIsActive() && phase != TuningPhase.COMPLETE && !isStopRequested()) {
 
             if (gamepad1.y && !lastY) {
                 isPaused = !isPaused;
@@ -152,7 +152,7 @@ public class FollowerTuner extends LinearOpMode {
                     state == TuningState.LATERAL_ACCEL_TEST)) {
 
                 follower.teleOpDrive(0, 0, 0);
-                telemetry.addLine("AUTO TUNER PAUSED. Press 'Y' to resume.");
+                telemetry.addLine("Tuner Paused, Y to resume.");
 
                 lastA = gamepad1.a;
                 lastB = gamepad1.b;
@@ -170,8 +170,8 @@ public class FollowerTuner extends LinearOpMode {
                     switch (state) {
                         case AWAIT_CONFIRM:
                             telemetry.addLine(phase + " phase initialized");
-                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
-                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addLine("A - Toggle mode");
+                            telemetry.addLine("B - Start tuning");
                             telemetry.addData("Selected Mode", mode);
 
                             if (gamepad1.a && !lastA) {
@@ -219,13 +219,13 @@ public class FollowerTuner extends LinearOpMode {
                             ksLastGuess = ksGuess;
 
                             follower.teleOpDrive(0, 0, 0);
-                            sleep(500);
+                            timer.wait(500);
                             break;
 
                         case STEP_RESPONSE:
                             if (timer.time(TimeUnit.MILLISECONDS) >= 2000) {
                                 follower.teleOpDrive(0, 0, 0);
-                                sleep(500);
+                                timer.wait(500);
 
                                 double L = stepTimeStamp - (stepVelAtTimeStamp / stepMaxAccel);
                                 double kP = 1.2 / (L * stepMaxAccel);
@@ -274,8 +274,8 @@ public class FollowerTuner extends LinearOpMode {
                             telemetry.addData("Robot Pose", follower.getPose().toString());
 
                             if (!readyToRerun) {
-                                telemetry.addLine("Press 'A' (cross) to SAVE and advance.");
-                                telemetry.addLine("Press 'B' (circle) to RERUN or ADJUST.");
+                                telemetry.addLine("A - Save and advance");
+                                telemetry.addLine("B - Rerun tuner");
 
                                 if (mode == TuningMode.MANUAL) {
                                     telemetry.addLine("--- MANUAL TUNING ---");
@@ -305,8 +305,8 @@ public class FollowerTuner extends LinearOpMode {
                                     readyToRerun = true;
                                 }
                             } else {
-                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
-                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addLine("A - Toggle mode");
+                                telemetry.addLine("B - Rerun tuner");
                                 telemetry.addData("Selected Mode", mode);
 
                                 if (gamepad1.a && !lastA) {
@@ -334,8 +334,8 @@ public class FollowerTuner extends LinearOpMode {
                     switch (state) {
                         case AWAIT_CONFIRM:
                             telemetry.addLine("Phase: VELOCITY_FF initialized");
-                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
-                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addLine("A - Toggle mode");
+                            telemetry.addLine("B - Start tuning");
                             telemetry.addData("Selected Mode", mode);
 
                             if (gamepad1.a && !lastA) {
@@ -354,11 +354,11 @@ public class FollowerTuner extends LinearOpMode {
 
                         case VELOCITY_FF:
                             follower.teleOpDrive(0, 1.0, 0);
-                            sleep(1500);
+                            timer.wait(1500);
                             double maxVel = Math.abs(follower.getVelocity().getPos().getX().getIn());
                             velocityFF = 1.0 / maxVel;
                             follower.teleOpDrive(0, 0, 0);
-                            sleep(500);
+                            timer.wait(500);
                             updateFollowerConfig();
                             readyToRerun = false;
                             state = TuningState.CONFIRM;
@@ -369,8 +369,8 @@ public class FollowerTuner extends LinearOpMode {
                             telemetry.addData("Robot Pose", follower.getPose().toString());
 
                             if (!readyToRerun) {
-                                telemetry.addLine("Press 'A' (cross) to SAVE and advance.");
-                                telemetry.addLine("Press 'B' (circle) to RERUN or ADJUST.");
+                                telemetry.addLine("A - Save and advance");
+                                telemetry.addLine("B - Rerun tuner");
 
                                 if (mode == TuningMode.MANUAL) {
                                     telemetry.addLine("--- MANUAL TUNING ---");
@@ -392,8 +392,8 @@ public class FollowerTuner extends LinearOpMode {
                                     readyToRerun = true;
                                 }
                             } else {
-                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
-                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addLine("A - Toggle mode");
+                                telemetry.addLine("B - Execute rerun");
                                 telemetry.addData("Selected Mode", mode);
 
                                 if (gamepad1.a && !lastA) {
@@ -418,8 +418,8 @@ public class FollowerTuner extends LinearOpMode {
                     switch (state) {
                         case AWAIT_CONFIRM:
                             telemetry.addLine("Phase: LATERAL_ACCEL initialized");
-                            telemetry.addLine("Press 'A' (cross) to TOGGLE mode.");
-                            telemetry.addLine("Press 'B' (circle) to START tuning.");
+                            telemetry.addLine("A - Toggle mode");
+                            telemetry.addLine("B - Start tuning");
                             telemetry.addData("Selected Mode", mode);
 
                             if (gamepad1.a && !lastA) {
@@ -472,7 +472,7 @@ public class FollowerTuner extends LinearOpMode {
                                     maxLateralAccel -= 20.0;
                                 } else {
                                     maxLateralAccel += 20.0;
-                                    sleep(1000);
+                                    timer.wait(1000);
                                 }
                                 state = TuningState.LATERAL_ACCEL;
                             }
@@ -502,8 +502,8 @@ public class FollowerTuner extends LinearOpMode {
                                     readyToRerun = true;
                                 }
                             } else {
-                                telemetry.addLine("Press 'A' (cross) to TOGGLE between AUTO and MANUAL mode.");
-                                telemetry.addLine("Press 'B' (circle) to EXECUTE rerun.");
+                                telemetry.addLine("A - Toggle mode");
+                                telemetry.addLine("B - Execute Rerun");
                                 telemetry.addData("Selected Mode", mode);
 
                                 if (gamepad1.a && !lastA) {
@@ -537,7 +537,7 @@ public class FollowerTuner extends LinearOpMode {
             telemetry.update();
         }
 
-        while (opModeIsActive()) {
+        while (opModeIsActive() && !isStopRequested()) {
             telemetry.addData("Status", "All Tuning Cycles Complete! Configuration Saved to JSON.");
             telemetry.update();
             follower.teleOpDrive(0, 0, 0);
@@ -603,6 +603,17 @@ public class FollowerTuner extends LinearOpMode {
             FileWriter fileWriter = new FileWriter(new File(outputFolder, "FollowerConstants.json"));
             fileWriter.write(jsonPayload);
             fileWriter.close();
-        } catch (IOException ignored) {}
+        } catch (IOException ignored) {
+            telemetry.addLine("WARNING: Values were not saved successfully");
+            telemetry.addData("Heading P", headingP);
+            telemetry.addData("Heading D", headingD);
+            telemetry.addData("Heading S", headingS);
+            telemetry.addData("Translation P", translationP);
+            telemetry.addData("Translation D", translationD);
+            telemetry.addData("Translation S", translationS);
+            telemetry.addData("Velocity FF", velocityFF);
+            telemetry.addData("Max Lateral Accel", maxLateralAccel);
+            telemetry.update();
+        }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/FollowerTuner.java
@@ -2,9 +2,11 @@ package org.firstinspires.ftc.teamcode.tuning;
 
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.util.ElapsedTime;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import core.ApexConfig;
 import core.Follower;
@@ -30,32 +32,44 @@ import org.firstinspires.ftc.teamcode.Constants;
  */
 @TeleOp(name = "Follower Tuner", group = "Apex Pathing Tuning")
 public class FollowerTuner extends LinearOpMode {
+
     enum TuningState {
-        HEADING,
-        TRANSLATION,
+        AWAIT_CONFIRM,
+        KS_SEARCH,
+        STEP_RESPONSE,
         VELOCITY_FF,
         LATERAL_ACCEL,
-        COMPLETE
+        LATERAL_ACCEL_TEST,
+        CONFIRM,
+        SAVE
     }
 
-    TuningState currentState = TuningState.HEADING;
+    enum TuningPhase { HEADING, TRANSLATION, VELOCITY_FF, LATERAL_ACCEL, COMPLETE }
 
-    private double headingP = 0.0, headingD = 0.0, headingS = 0.0;
-    private double translationP = 0.0, translationD = 0.0, translationS = 0.0;
-    private double velocityFF = 0.0;
+    private TuningPhase phase = TuningPhase.HEADING;
+    private TuningState state = TuningState.AWAIT_CONFIRM;
+
+    private double headingP, headingD, headingS;
+    private double translationP, translationD, translationS;
+    private double velocityFF;
     private double maxLateralAccel = 40.0;
-    private double headingToleranceDeg = 1.0;
-    private double distanceToleranceIn = 0.5;
-    private double tTolerance = 0.95;
+    private double headingToleranceDeg, distanceToleranceIn, tTolerance;
 
-    private Follower follower;
+    private double ksMax = 0.2, ksMin = 0.0, ksGuess = 0.0, ksLastGuess = -1.0, ksMaxDeviation;
+    private double stepMaxAccel, stepMaxVel, stepLastVel, stepLastTime, stepStartTime, stepTimeStamp, stepVelAtTimeStamp;
+    private double accelMaxError;
+    private boolean driftDetected;
+
+    private final ElapsedTime timer = new ElapsedTime();
     private final Constants baseConstants = new Constants();
     private final FollowerConstants followerConstants = new FollowerConstants();
+    private Follower follower;
+
+    private boolean lastA = false;
 
     @Override
     public void runOpMode() throws InterruptedException {
         FollowerConstants defaults = baseConstants.followerConfig().loadFromJson();
-
         headingP = defaults.headingCoeffs.kP;
         headingD = defaults.headingCoeffs.kD;
         headingS = defaults.headingCoeffs.kS;
@@ -69,143 +83,295 @@ public class FollowerTuner extends LinearOpMode {
         maxLateralAccel = defaults.maxLateralAccel > 10 ? defaults.maxLateralAccel : 40.0;
 
         while (opModeInInit()) {
-            telemetry.addLine("ROBOT INITIALIZED - FULLY AUTOMATED TUNING MODE");
-            telemetry.addLine("1. Ensure 6x6 feet of clear floor space.");
-            telemetry.addLine("2. Place robot at the center-back of the area.");
-            telemetry.addLine("3. Press START to begin the full auto-tuning sequence.");
+            telemetry.addLine("Robot Initialized");
+            telemetry.addLine("Tuning order:\n 1) Heading PDS \n 2) Translation PDS \n 3) Velocity FF \n 4) Max Lateral Accel");
+            telemetry.addLine("Run the OpMode to proceed with the Heading Tuner");
+            telemetry.addLine("Press 'A' (cross) to directly run the Translation Tuner if you have already run the Heading Tuner");
+            telemetry.addLine("Press 'B' (circle) to directly run the Velocity FF Tuner if you have already run the Heading Tuner and Translation Tuner");
+            telemetry.addLine("Once all of these 3 tuners are complete, press 'A' (circle) to run the Max Lateral Acceleration Tuner");
+            telemetry.addLine("IMPORTANT: Do NOT run the tuners out of order");
+
+            if (gamepad1.a) {
+                phase = TuningPhase.TRANSLATION;
+            } else if (gamepad1.b) {
+                phase = TuningPhase.VELOCITY_FF;
+            }
+
+            telemetry.addData("Selected Phase", phase);
             telemetry.update();
         }
 
         updateFollowerConfig();
         follower = new Follower(customConfig, hardwareMap);
-        follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN),Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
 
         waitForStart();
 
-        autoTuneHeading();
-        autoTuneTranslation();
-        autoTuneVelocityFF();
-        autoTuneMaxLateralAccel();
+        while (opModeIsActive() && phase != TuningPhase.COMPLETE && !isStopRequested()) {
+            switch (phase) {
+                case HEADING:
+                case TRANSLATION: {
+                    boolean isAngular = phase == TuningPhase.HEADING;
+                    switch (state) {
+                        case AWAIT_CONFIRM:
+                            telemetry.addLine("Press 'A' to proceed with the " + phase + " tuner");
+                            telemetry.update();
+                            if (gamepad1.a && !lastA) {
+                                resetKsSearch();
+                                state = TuningState.KS_SEARCH;
+                            }
+                            break;
 
-        currentState = TuningState.COMPLETE;
-        saveConstantsToJson();
+                        case KS_SEARCH:
+                            if (Math.abs(ksLastGuess - ksGuess) <= 0.01) {
+                                if (isAngular) headingS = ksGuess;
+                                else translationS = ksGuess;
+                                resetStepResponse();
+                                state = TuningState.STEP_RESPONSE;
+                                break;
+                            }
+
+                            follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN), Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
+                            follower.update();
+                            ksGuess = (ksMax + ksMin) / 2.0;
+                            ksMaxDeviation = 0.0;
+                            timer.reset();
+
+                            while (opModeIsActive() && timer.time(TimeUnit.MILLISECONDS) < 500) {
+                                follower.update();
+                                double pos = isAngular
+                                        ? follower.getPose().getHeading().getRad()
+                                        : follower.getPose().getPos().getX().getIn();
+                                ksMaxDeviation = Math.max(Math.abs(pos), ksMaxDeviation);
+                                if (isAngular) follower.teleOpDrive(0, 0, ksGuess);
+                                else follower.teleOpDrive(ksGuess, 0, 0);
+                            }
+
+                            if (ksMaxDeviation > 0.025) ksMax = ksGuess;
+                            else ksMin = ksGuess;
+                            ksLastGuess = ksGuess;
+
+                            follower.teleOpDrive(0, 0, 0);
+                            sleep(500);
+                            break;
+
+                        case STEP_RESPONSE:
+                            if (timer.time(TimeUnit.MILLISECONDS) >= 2000) {
+                                follower.teleOpDrive(0, 0, 0);
+                                sleep(500);
+
+                                double L = stepTimeStamp - (stepVelAtTimeStamp / stepMaxAccel);
+                                double kP = 1.2 / (L * stepMaxAccel);
+                                double kD = 0.6 / stepMaxAccel;
+
+                                if (isAngular) {
+                                    headingP = kP > 0 ? kP : 0.01;
+                                    headingD = kD > 0 ? kD : 0.001;
+                                } else {
+                                    translationP = Double.isFinite(kP) && kP > 0 ? kP : 0.01;
+                                    translationD = Double.isFinite(kD) && kD > 0 ? kD : 0.001;
+                                }
+
+                                updateFollowerConfig();
+                                state = TuningState.CONFIRM;
+                                break;
+                            }
+
+                            follower.update();
+                            double curVel = isAngular
+                                    ? follower.getVelocity().getHeading().getRad()
+                                    : follower.getVelocity().getPos().getX().getIn();
+
+                            double now = System.nanoTime();
+                            double deltaT = (now - stepLastTime) / 1e9;
+                            double deltaV = curVel - stepLastVel;
+                            double accel = deltaT > 1e-6 ? deltaV / deltaT : 0.0;
+
+                            if (accel > stepMaxAccel) {
+                                stepMaxAccel = accel;
+                                stepTimeStamp = (now - stepStartTime) / 1e9;
+                                stepVelAtTimeStamp = curVel;
+                            }
+
+                            stepMaxVel = Math.max(curVel, stepMaxVel);
+                            stepLastVel = curVel;
+                            stepLastTime = now;
+
+                            if (isAngular) follower.teleOpDrive(0, 0, 1.0);
+                            else follower.teleOpDrive(1.0, 0, 0);
+                            break;
+
+                        case CONFIRM:
+                            telemetry.addData("Current Phase", phase);
+                            telemetry.addLine("Press 'A' to accept and advance.");
+                            if (isAngular) {
+                                telemetry.addData("Heading P", headingP);
+                                telemetry.addData("Heading D", headingD);
+                                telemetry.addData("Heading S", headingS);
+                            } else {
+                                telemetry.addData("Translation P", translationP);
+                                telemetry.addData("Translation D", translationD);
+                                telemetry.addData("Translation S", translationS);
+                            }
+                            telemetry.addData("Robot Pose", follower.getPose().toString());
+                            telemetry.update();
+
+                            follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
+
+                            if (gamepad1.a && !lastA) {
+                                phase = isAngular ? TuningPhase.TRANSLATION : TuningPhase.VELOCITY_FF;
+                                state = TuningState.AWAIT_CONFIRM;
+                                resetKsSearch();
+                            }
+                            break;
+                    }
+                    break;
+                }
+
+                case VELOCITY_FF: {
+                    switch (state) {
+                        case AWAIT_CONFIRM:
+                            telemetry.addLine("Press 'A' to proceed with the VELOCITY_FF tuner");
+                            telemetry.update();
+                            if (gamepad1.a && !lastA) {
+                                state = TuningState.VELOCITY_FF;
+                            }
+                            break;
+
+                        case VELOCITY_FF:
+                            follower.teleOpDrive(0, 1.0, 0);
+                            sleep(1500);
+                            double maxVel = Math.abs(follower.getVelocity().getPos().getX().getIn());
+                            velocityFF = 1.0 / maxVel;
+                            follower.teleOpDrive(0, 0, 0);
+                            sleep(500);
+                            updateFollowerConfig();
+                            state = TuningState.CONFIRM;
+                            break;
+
+                        case CONFIRM:
+                            telemetry.addData("Current Phase", phase);
+                            telemetry.addLine("Press 'A' to accept and advance.");
+                            telemetry.addData("Velocity FF (kV)", velocityFF);
+                            telemetry.addData("Robot Pose", follower.getPose().toString());
+                            telemetry.update();
+
+                            follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
+
+                            if (gamepad1.a && !lastA) {
+                                phase = TuningPhase.LATERAL_ACCEL;
+                                state = TuningState.AWAIT_CONFIRM;
+                                maxLateralAccel = 50.0;
+                                driftDetected = false;
+                            }
+                            break;
+                    }
+                    break;
+                }
+
+                case LATERAL_ACCEL: {
+                    switch (state) {
+                        case AWAIT_CONFIRM:
+                            telemetry.addLine("Press 'A' to proceed with the LATERAL_ACCEL tuner");
+                            telemetry.update();
+                            if (gamepad1.a && !lastA) {
+                                state = TuningState.LATERAL_ACCEL;
+                            }
+                            break;
+
+                        case LATERAL_ACCEL:
+                            if (driftDetected || maxLateralAccel > 300) {
+                                if (!driftDetected) maxLateralAccel -= 20.0;
+                                updateFollowerConfig();
+                                state = TuningState.CONFIRM;
+                                break;
+                            }
+
+                            updateFollowerConfig();
+                            follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN), Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
+
+                            Pose start = follower.getPose();
+                            Path testCurve = Builder.path(
+                                    start,
+                                    new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(0, DistUnit.IN))), start.getHeading()),
+                                    new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(30, DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(90))),
+                                    new Pose(start.getPos().plus(new Vector(Dist.of(0, DistUnit.IN), Dist.of(30, DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(180)))
+                            ).build();
+
+                            follower.follow(testCurve);
+                            accelMaxError = 0;
+                            state = TuningState.LATERAL_ACCEL_TEST;
+                            break;
+
+                        case LATERAL_ACCEL_TEST:
+                            follower.update();
+                            double err = follower.getPose().getPos().getMag().getIn();
+                            if (err > accelMaxError) accelMaxError = err;
+
+                            if (!follower.isBusy()) {
+                                if (accelMaxError > 4.0) {
+                                    driftDetected = true;
+                                    maxLateralAccel -= 20.0;
+                                } else {
+                                    maxLateralAccel += 20.0;
+                                    sleep(1000);
+                                }
+                                state = TuningState.LATERAL_ACCEL;
+                            }
+                            break;
+
+                        case CONFIRM:
+                            telemetry.addData("Current Phase", phase);
+                            telemetry.addLine("Press 'A' to accept and finish.");
+                            telemetry.addData("Max Lateral Accel", maxLateralAccel);
+                            telemetry.addData("Robot Pose", follower.getPose().toString());
+                            telemetry.update();
+
+                            follower.teleOpDrive(-gamepad1.left_stick_x, gamepad1.left_stick_y, -gamepad1.right_stick_x);
+
+                            if (gamepad1.a && !lastA) {
+                                state = TuningState.SAVE;
+                            }
+                            break;
+
+                        case SAVE:
+                            saveConstantsToJson();
+                            phase = TuningPhase.COMPLETE;
+                            break;
+                    }
+                    break;
+                }
+            }
+
+            lastA = gamepad1.a;
+            telemetry.update();
+        }
 
         while (opModeIsActive()) {
-            telemetry.addData("Status", "AUTOMATED TUNING COMPLETE");
-            telemetry.addLine("Constants saved to /sdcard/FIRST/FollowerConstants.json");
+            telemetry.addData("Status", "All Tuning Cycles Complete! Configuration Saved to JSON.");
             telemetry.update();
             follower.teleOpDrive(0, 0, 0);
         }
     }
 
-    private void autoTuneHeading() {
-        telemetry.addLine("PHASE 1/4: Tuning Heading (PDS)");
-        telemetry.update();
-
-        double power = 0;
-        while (opModeIsActive() && Math.abs(follower.getVelocity().getHeading().getRad()) < 0.02) {
-            power += 0.0005;
-            follower.teleOpDrive(0, 0, power);
-            sleep(10);
-        }
-        headingS = power;
-        follower.teleOpDrive(0, 0, 0);
-        sleep(500);
-
-        headingP = 0.1;
-        boolean settled = false;
-        while (opModeIsActive() && !settled) {
-            updateFollowerConfig();
-            Angle target = Angle.fromDeg(90);
-            long startTime = System.currentTimeMillis();
-
-            while (opModeIsActive() && Math.abs(follower.getPose().getHeading().minus(target).getDeg()) > 1.0) {
-                if (System.currentTimeMillis() - startTime > 2500) break;
-                follower.teleOpDrive(0, 0, 0); // Follower logic handles PDS via update/follow if implemented,
-                // otherwise we use teleOpDrive as a placeholder for controller update
-                sleep(10);
-            }
-
-            if (Math.abs(follower.getPose().getHeading().minus(target).getDeg()) < 1.0) settled = true;
-            else headingP += 0.05;
-        }
-        sleep(500);
+    private void resetKsSearch() {
+        ksMax = 0.2;
+        ksMin = 0.0;
+        ksGuess = 0.0;
+        ksLastGuess = -1.0;
+        ksMaxDeviation = 0.0;
     }
 
-    private void autoTuneTranslation() {
-        telemetry.addLine("PHASE 2/4: Tuning Translation (PDS)");
-        telemetry.update();
+    private void resetStepResponse() {
+        stepMaxAccel = 0;
+        stepMaxVel = 0;
+        stepLastVel = 0;
+        stepTimeStamp = 0;
+        stepVelAtTimeStamp = 0;
+        stepLastTime = System.nanoTime();
+        stepStartTime = System.nanoTime();
+        timer.reset();
 
-        double power = 0;
-        while (opModeIsActive() && Math.abs(follower.getVelocity().getPos().getX().getIn()) < 0.1) {
-            power += 0.001;
-            follower.teleOpDrive(0, power, 0);
-            sleep(10);
-        }
-        translationS = power;
-        follower.teleOpDrive(0, 0, 0);
-        sleep(500);
-
-        translationP = 0.05;
-        translationD = 0.01;
-    }
-
-    private void autoTuneVelocityFF() {
-        telemetry.addLine("PHASE 3/4: Tuning Velocity Feedforward (kV)");
-        telemetry.update();
-
-        follower.teleOpDrive(0, 1.0, 0);
-        sleep(1500);
-        double maxVel = Math.abs(follower.getVelocity().getPos().getX().getIn());
-        velocityFF = 1.0 / maxVel;
-        follower.teleOpDrive(0, 0, 0);
-        sleep(500);
-    }
-
-    private void autoTuneMaxLateralAccel() {
-        telemetry.addLine("PHASE 4/4: Tuning Max Lateral Acceleration");
-        telemetry.update();
-
-        maxLateralAccel = 50.0;
-        boolean driftDetected = false;
-
-        while (opModeIsActive() && !driftDetected) {
-            updateFollowerConfig();
-            follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN),Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
-
-            generateAndFollowTestCurve();
-
-            double maxError = 0;
-            while (opModeIsActive() && follower.isBusy()) {
-                follower.update();
-                double currentError = follower.getPose().getPos().getMag().getIn();  if (currentError > maxError) maxError = currentError;
-                telemetry.addData("Testing Limit", maxLateralAccel);
-                telemetry.addData("Current Gs", Math.abs(follower.getAcceleration().getY().getIn()));
-                telemetry.update();
-            }
-
-            if (maxError > 4.0 || maxLateralAccel > 300) {
-                driftDetected = true;
-                maxLateralAccel -= 20.0;
-            } else {
-                maxLateralAccel += 20.0;
-                telemetry.addLine("Success. Increasing limit...");
-                telemetry.update();
-                sleep(1000);
-            }
-        }
-    }
-
-    private void generateAndFollowTestCurve() {
-        Pose start = follower.getPose();
-        Path testCurve = Builder.path(
-                start,
-                new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(0, DistUnit.IN))), start.getHeading()),
-                new Pose(start.getPos().plus(new Vector(Dist.of(30, DistUnit.IN), Dist.of(30,DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(90))),
-                new Pose(start.getPos().plus(new Vector(Dist.of(0, DistUnit.IN), Dist.of(30, DistUnit.IN))), start.getHeading().plus(Angle.fromDeg(180)))
-        ).build();
-
-        follower.follow(testCurve);
+        follower.setPose(new Pose(new Vector(Dist.of(0, DistUnit.IN), Dist.of(0, DistUnit.IN)), Angle.fromDeg(0)));
     }
 
     private void updateFollowerConfig() {


### PR DESCRIPTION
As promised, I completely rewrote the tuners. The advantages of the new system are:

- **Single unified tuner:**  No need to run 3 different tuners and note down 50 different values. This tunes every Follower constant there is to tune, completely automatically. You can even skip ahead in the tuning process if you ran a part of the OpMode and then turned your robot off to, say, change your battery :D
- **Values saved to control hub:** This is what actually enables the automatic tuning to work, and even allows the user to be able to turn off the robot but the values still get saved. Additionally, the values are saved to a JSON file as @DylanBPY suggested instead of a txt file as it was in the earlier iteration.
- **Updated FollowerConstants file:** As I ideated earlier, the FollowerConstants file now handles all the logic of assigning the follower constants determined through tuning. It simply reads the values through the control hub file and assigns variables with their respective values. This also eliminates the need to have to manually set FollowerConstants in the Constants file, allowing the Constants file to only deal with drivetrain and localizer constants.

Dylan and Joel, would like your review on this :D